### PR TITLE
Encode: single-pass packed-run detection

### DIFF
--- a/phpser.c
+++ b/phpser.c
@@ -853,24 +853,30 @@ static void encode_value_inner(smart_str *body, encode_ctx *e, zval *v) {
 static uint8_t detect_packed_run(encode_ctx *e, HashTable *ht, uint32_t n_used) {
     if (n_used == 0) return TAG_PACKED_MIXED;
     zval *zp = ht->arPacked;
-    uint8_t first = Z_TYPE(zp[0]);
-    if (first != IS_LONG && first != IS_DOUBLE && first != IS_STRING) {
-        return TAG_PACKED_MIXED;
-    }
-    for (uint32_t i = 1; i < n_used; i++) {
-        if (Z_TYPE(zp[i]) != first) return TAG_PACKED_MIXED;
-    }
-    switch (first) {
-        case IS_LONG:   return TAG_PACKED_LONGS;
-        case IS_DOUBLE: return TAG_PACKED_DOUBLES;
-        case IS_STRING: {
+    /* One pass per candidate type. The string case folds the homogeneity
+     * check and the dict-membership check into a single walk — previously a
+     * type-homogeneity pass followed by a separate dict pass — so a
+     * PACKED_STRINGS-eligible array is scanned once here instead of twice. */
+    switch (Z_TYPE(zp[0])) {
+        case IS_LONG:
+            for (uint32_t i = 1; i < n_used; i++) {
+                if (Z_TYPE(zp[i]) != IS_LONG) return TAG_PACKED_MIXED;
+            }
+            return TAG_PACKED_LONGS;
+        case IS_DOUBLE:
+            for (uint32_t i = 1; i < n_used; i++) {
+                if (Z_TYPE(zp[i]) != IS_DOUBLE) return TAG_PACKED_MIXED;
+            }
+            return TAG_PACKED_DOUBLES;
+        case IS_STRING:
             for (uint32_t i = 0; i < n_used; i++) {
+                if (Z_TYPE(zp[i]) != IS_STRING) return TAG_PACKED_MIXED;
                 intern_slot *s = enc_cache_find(e, Z_STR(zp[i]));
                 if (!s || !SLOT_IS_DICT(*s)) return TAG_PACKED_MIXED;
             }
             return TAG_PACKED_STRINGS;
-        }
-        default:        return TAG_PACKED_MIXED; /* unreachable */
+        default:
+            return TAG_PACKED_MIXED;
     }
 }
 


### PR DESCRIPTION
## Problem

`detect_packed_run` scanned a homogeneous string array **twice**: once for type homogeneity (`Z_TYPE(zp[i]) != first`), then again to confirm every element was already dict-bound. Combined with the emit loop in `encode_hashtable`, a `TAG_PACKED_STRINGS`-eligible array (the repeated `['a','b','c']` tags shape in rowset payloads) was walked three times.

## Fix

Fold the homogeneity check and the dict-membership check into a single per-type walk, and drop the now-redundant first-element type guard. The string case is scanned once in `detect_packed_run` instead of twice; the `LONG`/`DOUBLE` cases keep their single homogeneity pass. Also reads cleaner — one `switch` on the candidate type rather than a guard + loop + second switch.

No wire-format change.

## Testing

`make` clean (no warnings), all 38 PHPT tests pass — including `010-packed-arrays.phpt` and `040-string-dict.phpt`.

https://claude.ai/code/session_013Hr7jvAiP73KohKJP4DG2v

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hr7jvAiP73KohKJP4DG2v)_