### PR TITLE
HMAC: drop module-global for the SHA256 algo name

### DIFF
--- a/phpser.c
+++ b/phpser.c
@@ -1777,7 +1777,6 @@ static int decode_value_inner(decode_ctx *d, zval *out) {
 /* Cached at MINIT. ext/hash is mandatory since PHP 7.4 and lookup never
  * fails for a builtin algo; we still null-check defensively. */
 static const php_hash_ops *phpser_sha256_ops = NULL;
-static zend_string *phpser_sha256_name = NULL;
 
 /* HMAC-SHA256 of `data` under `key`. Writes a 32-byte tag to `out`.
  * Returns 0 on success, -1 if SHA256 ops aren't available. */
@@ -2277,18 +2276,16 @@ static PHP_MINIT_FUNCTION(phpser) {
 #endif
     /* Cache SHA256 ops for HMAC signing. ext/hash is mandatory since PHP
      * 7.4 so this never fails in normal builds; we still null-check at
-     * call time. The algo-name zend_string is interned/persistent for the
-     * module lifetime — `1` = persistent flag. */
-    phpser_sha256_name = zend_string_init("sha256", sizeof("sha256") - 1, 1);
-    phpser_sha256_ops = php_hash_fetch_ops(phpser_sha256_name);
+     * call time. php_hash_fetch_ops only reads the algo name for the table
+     * lookup — it doesn't retain the pointer — so the lookup zend_string is
+     * a transient stack-local released immediately, not a module global. */
+    zend_string *algo = zend_string_init("sha256", sizeof("sha256") - 1, 0);
+    phpser_sha256_ops = php_hash_fetch_ops(algo);
+    zend_string_release(algo);
     return SUCCESS;
 }
 
 static PHP_MSHUTDOWN_FUNCTION(phpser) {
-    if (phpser_sha256_name) {
-        zend_string_release(phpser_sha256_name);
-        phpser_sha256_name = NULL;
-    }
     phpser_sha256_ops = NULL;
     return SUCCESS;
 }


### PR DESCRIPTION
## Problem

`phpser_sha256_name` was a persistent module global, allocated in MINIT and torn down in MSHUTDOWN, even though it's only used for a single `php_hash_fetch_ops` lookup. `php_hash_fetch_ops` reads the algo name for its table lookup and returns a static ops pointer — it does **not** retain the name — so there's no reason to keep the string alive for the module lifetime.

## Fix

Use a transient request-heap `zend_string` released immediately after the fetch. Drops the global and the entire MSHUTDOWN release branch (MSHUTDOWN now just nulls `phpser_sha256_ops`).

## Testing

`make` clean (no warnings), all 38 PHPT tests pass — including `074-signed.phpt`, which exercises HMAC round-trip, tamper detection, and key isolation.

https://claude.ai/code/session_013Hr7jvAiP73KohKJP4DG2v

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hr7jvAiP73KohKJP4DG2v)_