### PR TITLE
Decode: assert the class_idx bound in dec_class_resolve

### DIFF
--- a/phpser.c
+++ b/phpser.c
@@ -1086,11 +1086,18 @@ static int dec_defer_wakeup(decode_ctx *d, zend_object *obj) {
 /* Resolve a class entry from a dict-indexed class name with memoization
  * keyed by class_idx. Sentinel (zend_class_entry *)-1 marks "tried,
  * not found" so we don't re-call zend_lookup_class_ex for missing
- * classes either. Caller still gets NULL for unknown classes. */
+ * classes either. Caller still gets NULL for unknown classes.
+ *
+ * class_idx < d->dict_len is a precondition: the ce_cache is sized to
+ * dict_len, so an out-of-range index would be an OOB read/write here.
+ * Every caller resolves the class name via dec_get_zstr (which bounds the
+ * index) before calling in, so this holds; the assert catches any future
+ * caller that forgets. */
 #define DEC_CE_MISSING ((zend_class_entry *)(uintptr_t)-1)
 static inline zend_class_entry *dec_class_resolve(
     decode_ctx *d, uint64_t class_idx, zend_string *class_name)
 {
+    ZEND_ASSERT(class_idx < d->dict_len);
     if (UNEXPECTED(!d->ce_cache)) {
         d->ce_cache = ecalloc(d->dict_len, sizeof(zend_class_entry *));
     }


### PR DESCRIPTION
## Problem

`ce_cache` is sized to `dict_len` and indexed by `class_idx`, so an out-of-range `class_idx` would be an OOB read/write in `dec_class_resolve`. Today every caller resolves the class name via `dec_get_zstr` (which bounds the index) before calling in, so the access is safe — but that precondition was implicit and a future caller could miss it.

## Fix

Make the invariant explicit with `ZEND_ASSERT(class_idx < d->dict_len)` plus a comment. Zero cost in release builds; trips loudly in debug builds if a new caller forgets the bound check.

## Testing

`make` clean (no warnings), all 38 PHPT tests pass.

https://claude.ai/code/session_013Hr7jvAiP73KohKJP4DG2v

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hr7jvAiP73KohKJP4DG2v)_