### PR TITLE
Build: guard ZEND_GET_MODULE behind the shared-build macros

### DIFF
--- a/phpser.c
+++ b/phpser.c
@@ -2344,4 +2344,11 @@ zend_module_entry phpser_module_entry = {
  * On NTS builds both macros expand to nothing. */
 ZEND_TSRMLS_CACHE_DEFINE()
 
+/* get_module() is the dynamic-loader entry point; emit it only for a shared
+ * build. A hypothetical static link into the PHP binary would otherwise get
+ * a duplicate/clashing symbol. The OR mirrors the MINIT TSRMLS guard so the
+ * hand-rolled dev Makefile (which defines ZEND_COMPILE_DL_EXT rather than
+ * COMPILE_DL_PHPSER) still produces a loadable .so for `make test`. */
+#if defined(COMPILE_DL_PHPSER) || defined(ZEND_COMPILE_DL_EXT)
 ZEND_GET_MODULE(phpser)
+#endif


### PR DESCRIPTION
## Problem

`ZEND_GET_MODULE(phpser)` was emitted unconditionally. `get_module()` is the dynamic-loader entry point; in a hypothetical static link into the PHP binary it would clash. Standard skeleton hygiene guards it behind the shared-build macro.

## Fix

Gate it on `COMPILE_DL_PHPSER || ZEND_COMPILE_DL_EXT` — the same pair the MINIT TSRMLS block already uses. The OR keeps the hand-rolled dev `Makefile` (which defines `ZEND_COMPILE_DL_EXT`, not `COMPILE_DL_PHPSER`) producing a loadable `.so` for `make test`.

## Testing

Confirmed `COMPILE_DL_PHPSER` is defined in the phpize build (`config.status`), so `get_module()` is still emitted. `make` clean (no warnings), all 38 PHPT tests pass (the suite loads the `.so` dynamically, exercising the entry point).

https://claude.ai/code/session_013Hr7jvAiP73KohKJP4DG2v

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hr7jvAiP73KohKJP4DG2v)_