### PR TITLE
docs: correct nesting-cap figure in SECURITY.md (4096 → 512)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,7 +60,7 @@ In scope:
   without the correct key.
 - `allowed_classes` bypass: a class outside the allowlist being
   instantiated as itself rather than `__PHP_Incomplete_Class`.
-- Recursion-depth or quadratic-blowup attacks that bypass the 4096
+- Recursion-depth or quadratic-blowup attacks that bypass the 512
   nesting cap or otherwise cause unbounded CPU/memory use from a
   bounded-size input.
 - Reference / cycle handling that produces dangling pointers or wrong


### PR DESCRIPTION
## Problem

`SECURITY.md` (Scope section) still quotes a **4096** nesting cap. The actual cap is `MAX_DEPTH = 512` — lowered in `be84af9` to stay under the ASAN stack budget, and the README already documents 512. A security policy quoting the wrong bound would misdirect anyone reporting a depth-bypass.

## Fix

Sync the figure to the implementation (512). Docs-only.

https://claude.ai/code/session_013Hr7jvAiP73KohKJP4DG2v

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hr7jvAiP73KohKJP4DG2v)_