### PR TITLE
Support PHP 8.2

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -24,7 +24,7 @@ jobs:
       - id: matrix
         uses: php/php-windows-builder/extension-matrix@v1
         with:
-          php-version-list: '8.3, 8.4, 8.5'
+          php-version-list: '8.2, 8.3, 8.4, 8.5'
 
   build:
     name: Build ${{ matrix.php-version }} ${{ matrix.ts }} ${{ matrix.arch }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4', '8.5']
+        php: ['8.2', '8.3', '8.4', '8.5']
 
     steps:
       - uses: actions/checkout@v6
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4']
+        php: ['8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v6
@@ -162,7 +162,7 @@ jobs:
       - id: matrix
         uses: php/php-windows-builder/extension-matrix@v1
         with:
-          php-version-list: '8.3, 8.4, 8.5'
+          php-version-list: '8.2, 8.3, 8.4, 8.5'
 
   windows:
     name: Windows ${{ matrix.php-version }} ${{ matrix.ts }} ${{ matrix.arch }}

--- a/.release-config
+++ b/.release-config
@@ -5,6 +5,7 @@ version_macro: PHP_PHPSER_VERSION
 version_file: php_phpser.h
 repo: iliaal/phpser
 build_matrix:
+  - PHP-8.2
   - PHP-8.3
   - PHP-8.4
   - PHP-8.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PHP 8.2 support (lowered the minimum from 8.3).
+
 ### Changed
 
 - Packed-array encode (numeric, double, and typed-string runs) now reserves

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ echo 'extension=phpser.so' | sudo tee /etc/php/conf.d/phpser.ini
 
 ### Pre-built binaries
 
-Pre-built `.dll`s for Windows (PHP 8.3-8.5, TS/NTS, x64) and `.so`s for
+Pre-built `.dll`s for Windows (PHP 8.2-8.5, TS/NTS, x64) and `.so`s for
 Linux glibc (x86_64, arm64) and macOS arm64 (PHP 8.4-8.5) are attached
 to each [GitHub release](https://github.com/iliaal/phpser/releases). PIE
 fetches the matching binary automatically; falls back to source-build
@@ -112,7 +112,7 @@ model.
 
 - **Signed payloads for integrity.** `phpser_serialize_signed($value, $key)` wraps the payload in an HMAC-SHA256 frame; `phpser_unserialize_signed($payload, $key)` verifies in constant time and rejects tampered or foreign-keyed input *before* any decoding work runs. Use this whenever the storage layer crosses a trust boundary: memcached, redis, files, cookies, anywhere an attacker who can write to the store could otherwise feed a crafted payload to your decoder. An empty key is rejected on both sides — a keyless HMAC is forgeable, so callers must supply real key material.
 - **Safe handling of untrusted input.** `allowed_classes` option on both unserialize entry points, matching PHP's native `unserialize($payload, ['allowed_classes' => ...])` shape: pass `false` to reject all classes, an array to allowlist specific ones, or `true` for the default. Disallowed classes decode as `__PHP_Incomplete_Class` with the original name preserved, never instantiated. Recursion depth is capped at 512 on both encode and decode (encode throws, decode returns `null`), and assoc decode uses `zend_hash_update` so duplicate-key payloads collapse to last-write-wins rather than phantom buckets.
-- **PHP 8.3+ (8.4, 8.5, master).** BSD 3-Clause.
+- **PHP 8.2+ (8.3, 8.4, 8.5, master).** BSD 3-Clause.
 
 ## Bench (opt PHP 8.4.22-dev NTS release, 1000 iters, median of 9 runs)
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=8.3"
+        "php": ">=8.2"
     },
     "php-ext": {
         "extension-name": "phpser",

--- a/phpser.c
+++ b/phpser.c
@@ -56,6 +56,22 @@
      ZEND_ACC_EXPLICIT_ABSTRACT_CLASS | ZEND_ACC_ENUM)
 #endif
 
+/* GC_DTOR drops a refcount and runs the destructor / GC-root check on a
+ * refcounted value. It first appeared in PHP 8.3; on 8.2 spell out the same
+ * expansion (zend_gc_delref / rc_dtor_func / gc_check_possible_root all exist
+ * unchanged on 8.2) so the reference-teardown call site stays version-agnostic. */
+#if PHP_VERSION_ID < 80300
+# define GC_DTOR(p) \
+	do { \
+		zend_refcounted_h *_p = &(p)->gc; \
+		if (zend_gc_delref(_p) == 0) { \
+			rc_dtor_func((zend_refcounted *)_p); \
+		} else { \
+			gc_check_possible_root((zend_refcounted *)_p); \
+		} \
+	} while (0)
+#endif
+
 /* Wire format version. Bump on any incompatible change. */
 #define PHPSER_VERSION 0x01
 
@@ -2391,7 +2407,12 @@ static int parse_unserialize_options(
                 zend_type_error(
                     "%s(): allowed_classes option must "
                     "be an array of class names, %s given",
-                    fname, zend_zval_value_name(cn));
+                    fname,
+#if PHP_VERSION_ID >= 80300
+                    zend_zval_value_name(cn));
+#else
+                    zend_zval_type_name(cn));
+#endif
                 return -1;
             }
             zend_string *lc = zend_string_tolower(Z_STR_P(cn));


### PR DESCRIPTION
Lowers the minimum to PHP 8.2 (8.1 stays out of scope — it needs an arPacked re-architecture). `config.m4` already has no version gate; the blockers were two 8.3-only APIs called unguarded, which built with warnings and aborted at runtime with `undefined symbol` on specific paths.

## The two 8.3-only APIs

- **`GC_DTOR(ref)`** (`phpser.c` reference-decode teardown, `decode_destroy`). `GC_DTOR` is an 8.3+ macro; on 8.2 it expanded to an implicit function declaration → undefined symbol at load/teardown. Fix: a shim under `#if PHP_VERSION_ID < 80300` that reproduces the 8.3 macro expansion verbatim — `zend_gc_delref` / `rc_dtor_func` / `gc_check_possible_root` all exist unchanged on 8.2, so the call site is untouched and the native macro is selected on 8.3+.
- **`zend_zval_value_name(cn)`** (bad-`allowed_classes` `TypeError` path). 8.3+ only. Fix: `#if PHP_VERSION_ID >= 80300` → native call, `#else` → `zend_zval_type_name(cn)` (the pre-8.3 equivalent; the 8.2 compiler itself suggests it). Minor wording shift on 8.2 — scalar literals report `int`/`bool`/`null` rather than 8.3's value-level `true`/`false`/`null`.

The existing `#if PHP_VERSION_ID >= 80400` guards (lazy objects, `ZEND_ACC_UNINSTANTIABLE` shim) are untouched.

## Floor / CI

- `composer.json` `>=8.3` → `>=8.2`; README version line.
- 8.2 added to the linux + macOS test matrices, the Windows `php-version-list` (tests + release), and `.release-config` `build_matrix`.

## Verification (local ASAN builds)

Both crash paths were exercised on 8.2 — they aborted with `undefined symbol` before the fix:

- **Reference-decode / `GC_DTOR` teardown**: decoded a payload with shared refs + a self-cycle (`ID_REF` slots in the id_table). Completes cleanly, shared-ref identity preserved, exit 0.
- **Bad `allowed_classes`**: passed `int`/`float`/`object`/`bool`/`null` elements. Each throws `TypeError` with a sensible type name, exit 0. No `symbol lookup error`, no abort.

Build: 0 warnings on 8.2/8.3/8.4. A differential (compile without the patch under `-Wimplicit-function-declaration`) confirms both warnings appear at `phpser.c:1424` and `:2394` without the fix and are gone with it. The 8.2-only shim is verified inert on 8.3+ (native macro/API selected, clean build).

Full suite, 0 failures:

| PHP | passed | skipped | failed |
|-----|--------|---------|--------|
| 8.2 | 40 | 1 | 0 |
| 8.3 | 39 | 2 | 0 |
| 8.4 | 40 | 1 | 0 |

(Skips are version-gated tests, e.g. 8.4 lazy objects.)